### PR TITLE
Allow scenarios to be associated with more than one topology

### DIFF
--- a/phenix/src/go/api/experiment/experiment.go
+++ b/phenix/src/go/api/experiment/experiment.go
@@ -160,7 +160,16 @@ func Create(ctx context.Context, opts ...CreateOption) error {
 			return fmt.Errorf("topology annotation missing from scenario")
 		}
 
-		if topo != o.topology {
+		var found bool
+
+		for _, t := range strings.Split(topo, ",") {
+			if t == o.topology {
+				found = true
+				break
+			}
+		}
+
+		if !found {
 			return fmt.Errorf("experiment/scenario topology mismatch")
 		}
 

--- a/phenix/src/go/web/handlers.go
+++ b/phenix/src/go/web/handlers.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"phenix/api/cluster"
@@ -1947,8 +1948,21 @@ func GetScenarios(w http.ResponseWriter, r *http.Request) {
 	allowed := make(map[string]*structpb.ListValue)
 
 	for _, s := range scenarios {
-		// We only care about scenarios pertaining to the given topology.
-		if t := s.Metadata.Annotations["topology"]; t != topo {
+		var (
+			// A scenario can be associated with more than one topology.
+			topos = strings.Split(s.Metadata.Annotations["topology"], ",")
+			found bool
+		)
+
+		for _, t := range topos {
+			// We only care about scenarios pertaining to the given topology.
+			if t == topo {
+				found = true
+				break
+			}
+		}
+
+		if !found {
 			continue
 		}
 


### PR DESCRIPTION
When annotating a scenario with a topology, a comma-separated list of topology names can be used if more than one applies.

closes #32