### PR TITLE
Use sane default for log file when shelling out to user apps

### DIFF
--- a/phenix/src/go/api/config/config.go
+++ b/phenix/src/go/api/config/config.go
@@ -258,6 +258,12 @@ func Delete(name string) error {
 			if err := delete(&c); err != nil {
 				return err
 			}
+
+			for _, hook := range hooks[c.Kind] {
+				if err := hook("delete", &c); err != nil {
+					// TODO: what to do w/ error?
+				}
+			}
 		}
 
 		return nil
@@ -268,7 +274,17 @@ func Delete(name string) error {
 		return fmt.Errorf("getting config '%s': %w", name, err)
 	}
 
-	return delete(c)
+	if err := delete(c); err != nil {
+		return err
+	}
+
+	for _, hook := range hooks[c.Kind] {
+		if err := hook("delete", c); err != nil {
+			// TODO: what to do w/ error?
+		}
+	}
+
+	return nil
 }
 
 func delete(c *store.Config) error {

--- a/phenix/src/go/app/app.go
+++ b/phenix/src/go/app/app.go
@@ -152,7 +152,7 @@ func ApplyApps(action Action, exp *types.Experiment) error {
 		}
 	}
 
-	if exp.Spec.Scenario != nil {
+	if exp.Spec.Scenario() != nil {
 		for _, app := range exp.Spec.Scenario().Apps() {
 			// Don't apply default apps again if configured via the Scenario.
 			if _, ok := defaultApps[app.Name()]; ok {
@@ -197,6 +197,11 @@ func ApplyApps(action Action, exp *types.Experiment) error {
 				return fmt.Errorf("applying experiment app %s for action %s: %w", a.Name(), action, err)
 			}
 		}
+	}
+
+	if action == ACTIONCONFIG || action == ACTIONPRESTART {
+		// just in case one of the apps added some nodes to the topology...
+		exp.Spec.SetDefaults()
 	}
 
 	return nil

--- a/phenix/src/go/app/user.go
+++ b/phenix/src/go/app/user.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"phenix/internal/common"
 	"phenix/internal/mm"
 	"phenix/scheduler"
 	"phenix/types"
+	"phenix/util"
 	"phenix/util/shell"
 )
 
@@ -86,14 +88,22 @@ func (this UserApp) shellOut(action Action, exp *types.Experiment) error {
 		return fmt.Errorf("marshaling experiment to JSON: %w", err)
 	}
 
+	var logFile string
+
+	if dir := filepath.Dir(common.LogFile); dir == "/var/log/phenix" {
+		logFile = dir + "/phenix-apps.log"
+	} else {
+		logFile = dir + "/.phenix-apps.log"
+	}
+
 	opts := []shell.Option{
 		shell.Command(cmdName),
 		shell.Args(string(action)),
 		shell.Stdin(data),
-		shell.Env( // TODO: update to reflect options provided by user
-			"PHENIX_LOG_LEVEL=DEBUG",
-			"PHENIX_LOG_FILE=/tmp/phenix-apps.log",
+		shell.Env(
 			"PHENIX_DIR="+common.PhenixBase,
+			"PHENIX_LOG_LEVEL="+util.GetEnv("PHENIX_LOG_LEVEL", "DEBUG"),
+			"PHENIX_LOG_FILE="+util.GetEnv("PHENIX_LOG_FILE", logFile),
 		),
 	}
 

--- a/phenix/src/go/cmd/root.go
+++ b/phenix/src/go/cmd/root.go
@@ -72,7 +72,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&phenixBase, "base-dir.phenix", "/phenix", "base phenix directory")
 	rootCmd.PersistentFlags().StringVar(&minimegaBase, "base-dir.minimega", "/tmp/minimega", "base minimega directory")
-	rootCmd.PersistentFlags().StringVar(&hostnameSuffixes, "hostname-suffixes", "", "hostname suffixes to strip")
+	rootCmd.PersistentFlags().StringVar(&hostnameSuffixes, "hostname-suffixes", "-minimega,-phenix", "hostname suffixes to strip")
 	// rootCmd.PersistentFlags().Int("log.verbosity", 0, "log verbosity (0 - 10)")
 	rootCmd.PersistentFlags().Bool("log.error-stderr", true, "log fatal errors to STDERR")
 

--- a/phenix/src/go/cmd/root.go
+++ b/phenix/src/go/cmd/root.go
@@ -37,6 +37,8 @@ var rootCmd = &cobra.Command{
 			errOut   = viper.GetBool("log.error-stderr")
 		)
 
+		common.LogFile = errFile
+
 		if err := store.Init(store.Endpoint(endpoint)); err != nil {
 			return fmt.Errorf("initializing storage: %w", err)
 		}

--- a/phenix/src/go/go.mod
+++ b/phenix/src/go/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.2
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hpcloud/tail v1.0.0
 	github.com/mitchellh/mapstructure v1.2.2
 	github.com/olekukonko/tablewriter v0.0.4

--- a/phenix/src/go/go.sum
+++ b/phenix/src/go/go.sum
@@ -152,10 +152,12 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5 h1:UImYN5qQ8tuGpGE16ZmjvcTtTw24zw1
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=

--- a/phenix/src/go/internal/common/common.go
+++ b/phenix/src/go/internal/common/common.go
@@ -5,8 +5,11 @@ import (
 )
 
 var (
-	PhenixBase       = "/phenix"
-	MinimegaBase     = "/tmp/minimega"
+	PhenixBase   = "/phenix"
+	MinimegaBase = "/tmp/minimega"
+
+	LogFile = "/var/log/phenix"
+
 	HostnameSuffixes string
 )
 

--- a/phenix/src/go/internal/mm/minimega.go
+++ b/phenix/src/go/internal/mm/minimega.go
@@ -564,25 +564,27 @@ func (Minimega) GetClusterHosts(schedOnly bool) (Hosts, error) {
 	return cluster, nil
 }
 
-func (Minimega) IsHeadnode(node string) bool {
+func (Minimega) Headnode() string {
 	// Get headnode details
 	hosts, _ := processNamespaceHosts("minimega")
 
 	if len(hosts) == 0 {
-		return false // ???
+		return "" // ???
 	}
 
 	headnode := hosts[0].Name
 
 	// Trim host name suffixes (like -minimega, or -phenix) potentially added to
 	// Docker containers by Docker Compose config.
-	headnode = common.TrimHostnameSuffixes(headnode)
+	return common.TrimHostnameSuffixes(headnode)
+}
 
+func (this Minimega) IsHeadnode(node string) bool {
 	// Trim node name suffixes (like -minimega, or -phenix) potentially added to
 	// Docker containers by Docker Compose config.
 	node = common.TrimHostnameSuffixes(node)
 
-	return node == headnode
+	return node == this.Headnode()
 }
 
 func (Minimega) GetVLANs(opts ...Option) (map[string]int, error) {

--- a/phenix/src/go/internal/mm/mm.go
+++ b/phenix/src/go/internal/mm/mm.go
@@ -27,6 +27,7 @@ type MM interface {
 	GetVMCaptures(...Option) []Capture
 
 	GetClusterHosts(bool) (Hosts, error)
+	Headnode() string
 	IsHeadnode(string) bool
 	GetVLANs(...Option) (map[string]int, error)
 }

--- a/phenix/src/go/internal/mm/package.go
+++ b/phenix/src/go/internal/mm/package.go
@@ -76,6 +76,10 @@ func GetClusterHosts(schedOnly bool) (Hosts, error) {
 	return DefaultMM.GetClusterHosts(schedOnly)
 }
 
+func Headnode() string {
+	return DefaultMM.Headnode()
+}
+
 func IsHeadnode(node string) bool {
 	return DefaultMM.IsHeadnode(node)
 }

--- a/phenix/src/go/tmpl/templates/minimega_script.tmpl
+++ b/phenix/src/go/tmpl/templates/minimega_script.tmpl
@@ -38,7 +38,7 @@ vm config schedule {{ index $.Schedules .General.Hostname }}
 vm config vcpus {{ .Hardware.VCPU }}
 vm config cpu {{ .Hardware.CPU }}
 vm config memory {{ .Hardware.Memory }}
-vm config snapshot {{ .General.Snapshot }}
+vm config snapshot {{ derefBool .General.Snapshot }}
         {{- if .General.Snapshot }}
 vm config disk {{ .Hardware.DiskConfig ($.SnapshotName .General.Hostname) }},writeback
         {{- else }}

--- a/phenix/src/go/tmpl/tmpl.go
+++ b/phenix/src/go/tmpl/tmpl.go
@@ -20,6 +20,10 @@ func GenerateFromTemplate(name string, data interface{}, w io.Writer) error {
 			return a + b
 		},
 		"derefBool": func(b *bool) bool {
+			if b == nil {
+				return false
+			}
+
 			return *b
 		},
 	}

--- a/phenix/src/go/types/version/v1/experiment.go
+++ b/phenix/src/go/types/version/v1/experiment.go
@@ -3,10 +3,10 @@ package v1
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"phenix/internal/common"
+	"phenix/internal/mm"
 	ifaces "phenix/types/interfaces"
 	v2 "phenix/types/version/v2"
 	"phenix/util"
@@ -216,9 +216,7 @@ func (this *ExperimentSpec) ScheduleNode(node, host string) error {
 }
 
 func (this ExperimentSpec) SnapshotName(node string) string {
-	hostname, _ := os.Hostname()
-
-	return fmt.Sprintf("%s_%s_%s_snapshot", hostname, this.ExperimentNameF, node)
+	return fmt.Sprintf("%s_%s_%s_snapshot", mm.Headnode(), this.ExperimentNameF, node)
 }
 
 type ExperimentStatus struct {

--- a/phenix/src/go/util/env.go
+++ b/phenix/src/go/util/env.go
@@ -1,0 +1,11 @@
+package util
+
+import "os"
+
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+
+	return fallback
+}


### PR DESCRIPTION
The following environment variables are set prior to shelling out to user apps: PHENIX_DIR, PHENIX_LOG_FILE, and PHENIX_LOG_LEVEL.

Users may export PHENIX_LOG_FILE and PHENIX_LOG_LEVEL themselves. If present, their values will be used. If not already present, PHENIX_LOG_FILE defaults to either $HOME/.phenix-apps.log or /var/log/phenix/phenix-apps.log, depending on what user is running phenix, and PHENIX_LOG_LEVEL defaults to DEBUG.

closes #69