### PR TITLE
Support advanced "vm config" options for topology nodes

### DIFF
--- a/phenix/src/go/tmpl/templates/minimega_script.tmpl
+++ b/phenix/src/go/tmpl/templates/minimega_script.tmpl
@@ -48,6 +48,9 @@ vm config disk {{ .Hardware.DiskConfig "" }}
 vm config qemu-append -vga qxl
         {{- end }}
 vm config net {{ .Network.InterfaceConfig }}
+        {{- range $config, $value := .Advanced }}
+vm config {{ $config }} {{ $value }}
+        {{- end }}
 vm launch {{ .General.VMType }} {{ .General.Hostname }}
     {{- end }}
 {{- end }}

--- a/phenix/src/go/types/interfaces/topology.go
+++ b/phenix/src/go/types/interfaces/topology.go
@@ -14,9 +14,12 @@ type NodeSpec interface {
 	Hardware() NodeHardware
 	Network() NodeNetwork
 	Injections() []NodeInjection
+	Advanced() map[string]string
 
 	AddInject(string, string, string, string)
 	SetInjections([]NodeInjection)
+	SetAdvanced(map[string]string)
+	AddAdvanced(string, string)
 }
 
 type NodeGeneral interface {

--- a/phenix/src/go/types/version/v0/node.go
+++ b/phenix/src/go/types/version/v0/node.go
@@ -48,6 +48,10 @@ func (this Node) Injections() []ifaces.NodeInjection {
 	return injects
 }
 
+func (Node) Advanced() map[string]string {
+	return nil
+}
+
 func (this *Node) AddInject(src, dst, perms, desc string) {
 	this.InjectionsF = append(this.InjectionsF, &Injection{
 		SrcF:         src,
@@ -66,6 +70,9 @@ func (this *Node) SetInjections(injections []ifaces.NodeInjection) {
 
 	this.InjectionsF = injects
 }
+
+func (Node) SetAdvanced(map[string]string) {}
+func (Node) AddAdvanced(string, string)    {}
 
 type General struct {
 	HostnameF    string `json:"hostname" yaml:"hostname" structs:"hostname" mapstructure:"hostname"`

--- a/phenix/src/go/types/version/v1/node.go
+++ b/phenix/src/go/types/version/v1/node.go
@@ -16,6 +16,7 @@ type Node struct {
 	HardwareF   *Hardware         `json:"hardware" yaml:"hardware" structs:"hardware" mapstructure:"hardware"`
 	NetworkF    *Network          `json:"network" yaml:"network" structs:"network" mapstructure:"network"`
 	InjectionsF []*Injection      `json:"injections" yaml:"injections" structs:"injections" mapstructure:"injections"`
+	AdvancedF   map[string]string `json:"advanced" yaml:"advanced" structs:"advanced" mapstructure:"advanced"`
 }
 
 func (this Node) Labels() map[string]string {
@@ -46,6 +47,10 @@ func (this Node) Injections() []ifaces.NodeInjection {
 	}
 
 	return injects
+}
+
+func (this Node) Advanced() map[string]string {
+	return this.AdvancedF
 }
 
 func (this *Node) AddInject(src, dst, perms, desc string) {
@@ -80,6 +85,18 @@ func (this *Node) SetInjections(injections []ifaces.NodeInjection) {
 	}
 
 	this.InjectionsF = injects
+}
+
+func (this *Node) SetAdvanced(adv map[string]string) {
+	this.AdvancedF = adv
+}
+
+func (this *Node) AddAdvanced(config, value string) {
+	if this.AdvancedF == nil {
+		this.AdvancedF = make(map[string]string)
+	}
+
+	this.AdvancedF[config] = value
 }
 
 type General struct {
@@ -235,6 +252,10 @@ func (this *Node) SetDefaults() {
 
 	if this.HardwareF.OSTypeF == "" {
 		this.HardwareF.OSTypeF = "linux"
+	}
+
+	if this.AdvancedF == nil {
+		this.AdvancedF = make(map[string]string)
 	}
 
 	this.NetworkF.SetDefaults()

--- a/phenix/src/go/types/version/v1/schema.go
+++ b/phenix/src/go/types/version/v1/schema.go
@@ -427,6 +427,9 @@ components:
                 type: string
                 title: Injected file permissions (UNIX style)
                 example: 0664
+        advanced:
+          type: object
+          title: Advanced options for minimega vm config
     iface:
       type: object
       required:


### PR DESCRIPTION
For example, in the sample topology spec below, we add an advanced option for the `qemu-append` minimega vm config option:

```
spec:
  nodes:
  - type: VirtualMachine
    general:
      hostname: host-01
      snapshot: true
    hardware:
      os_type: linux
      drives:
      - image: miniccc.qc2
    advanced:
      qemu-append: -rtc driftfix=slew -cpu Haswell-noTSX-IBRS,hv_relaxed,hv_spinlocks=0x1fff,hv_vapic,hv_time
```

Note that by default phenix sets qemu-append to `-vga qxl` if the VM is running Linux. In the above example, `-vga qxl` would be replaced by what's in the node config.

Also note that **any** minimega vm config option can be specified in the `advanced` section, and will replace the config option if it was already set previously. The advanced options get set at the very end of the vm config step. As an example of this, the above example sets the minimega vm config snapshot option to true. If one were to specify `snapshot: "false"` in the `advanced` section of the node config, it would overwrite the snapshot setting specified in the `general` section.

closes #74