### PR TITLE
Add image inject-miniccc subcommand

### DIFF
--- a/phenix/src/go/tmpl/templates/miniccc/miniccc-scheduler.cmd
+++ b/phenix/src/go/tmpl/templates/miniccc/miniccc-scheduler.cmd
@@ -1,0 +1,2 @@
+schtasks /create /tn "miniccc" /sc onlogon /rl highest /tr "C:\minimega\miniccc.exe -serial \\.\Global\cc" /F
+schtasks /run /tn "miniccc"

--- a/phenix/src/go/tmpl/templates/miniccc/miniccc.init
+++ b/phenix/src/go/tmpl/templates/miniccc/miniccc.init
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides: miniccc startup
+# Required-Start:	$syslog $local_fs 
+# Required-Stop:	$syslog $local_fs 
+# Default-Start:	5
+# Default-Stop:		0 1 6
+# Short-Description: miniccc Agent
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+PROG=miniccc
+PIDFILE=/var/run/$PROG.pid
+DESC="miniccc Agent"
+
+start() {
+	log_daemon_msg "Starting $DESC" "$PROG"
+	start_daemon -p $PIDFILE /usr/local/bin/$PROG -serial /dev/virtio-ports/cc
+
+	if [ $? -ne 0 ]; then
+		log_end_msg 1
+		exit 1
+	fi
+
+	if [ $? -eq 0 ]; then
+		log_end_msg 0
+	fi
+
+	exit 0
+}
+
+stop() {
+	log_daemon_msg "Stopping $DESC" "$PROG"
+	killproc -p $PIDFILE
+
+	if [ $? -ne 0 ]; then
+		log_end_msg 1
+		exit 1
+	fi
+
+	if [ $? -eq 0 ]; then
+		log_end_msg 0
+	fi
+
+	exit 0
+}
+
+force_reload() {
+	stop
+	start
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	force-reload)
+		force_reload
+		;;
+	restart)
+		stop
+		start
+		;;
+	*)
+		echo "$Usage: $prog {start|stop|force-reload|restart}"
+		exit 2
+esac

--- a/phenix/src/go/tmpl/templates/miniccc/miniccc.service
+++ b/phenix/src/go/tmpl/templates/miniccc/miniccc.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=miniccc Agent
+
+[Service]
+ExecStart=/usr/local/bin/miniccc -serial /dev/virtio-ports/cc
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
New subcommand that injects miniccc and relevant boot scripts into an existing disk image. Supports both Windows and Linux, and for Linux supports both systemd and sysinitv.

related to #89